### PR TITLE
Add role restriction to config commands

### DIFF
--- a/bot/commands/ReactionRoles.js
+++ b/bot/commands/ReactionRoles.js
@@ -1,29 +1,55 @@
 const { getArgs }  = require('../Tools.js');
-const { ReactionRoles } = require('../languages/fr.json');
+const { ReactionRoles, AccessDenied } = require('../languages/fr.json');
 const Database     = require('../Database.js');
 
 function rrMenu(message) {
     const [command] = getArgs(message);
 
+    const isAdmin = message.member.roles.cache.get('492407354537541635');
+        
     switch(command) {
         case 'create':
+            if(!isAdmin) {
+                message.channel.send(AccessDenied);
+                return;
+            }
             createMenu(message);
             break;
         case 'modify':
+            if(!isAdmin) {
+                message.channel.send(AccessDenied);
+                return;
+            }
             modifyMenu(message);
             break;
         case 'delete':
+            if(!isAdmin) {
+                message.channel.send(AccessDenied);
+                return;
+            }
             deleteMenu(message);
             break;
         case 'add':
+            if(!isAdmin) {
+                message.channel.send(AccessDenied);
+                return;
+            }
             addRoleToMenu(message);
             break;
         case 'remove':
+            if(!isAdmin) {
+                message.channel.send(AccessDenied);
+                return;
+            }
             removeRoleFromMenu(message);
             break;
         case 'next':
         case 'val':
         case 'end' :
+            if(!isAdmin) {
+                message.channel.send(AccessDenied);
+                return;
+            }
             break;
         case 'help':
         default:

--- a/bot/commands/Stream.js
+++ b/bot/commands/Stream.js
@@ -1,10 +1,15 @@
 const Database     = require('../Database.js');
 const { getReply } = require('../Tools.js');
 
-const { StreamTxt, ErrorTxt, NotUnderstoodTxt } = require('../languages/fr.json');
+const { StreamTxt, ErrorTxt, NotUnderstoodTxt, AccessDenied } = require('../languages/fr.json');
 
 async function config(message) {
     try {
+        const isAdmin = message.member.roles.cache.get('492407354537541635');
+        if(!isAdmin) {
+            message.channel.send(AccessDenied);
+            return;
+        }
         const guildId = message.guild.id;
         const [result]  = await Database.getStreaming(guildId);
 

--- a/bot/languages/fr.json
+++ b/bot/languages/fr.json
@@ -1,4 +1,6 @@
 {
+    "AccessDenied": "Vous ne disposez pas des droits pour faire cette action.",
+    
     "StreamTxt": {
         "AlreadyConfig": "Il y a déjà une configuration pour mon service d'annonce de stream sur ton serveur. Voici les paramètres :",
         "AskChannel": "Ok, ensuite il me faut l'identifiant du canal dans lequel tu veux que j'annonce le stream.\rTu peux le trouver en faisant un clic droit sur le canal et \"Copier l'identifiant\".",


### PR DESCRIPTION
Not everyone should be able to access bot's server configuration.
Role is hard coded, waiting for decision from community staff.